### PR TITLE
Enable pitch correction

### DIFF
--- a/GT4SoundTool/Program.cs
+++ b/GT4SoundTool/Program.cs
@@ -198,8 +198,9 @@ public class Program
                     int pan = (int)Normalize(splitChunk.Pan, 0, 128, -500, 500);
                     sf2.AddInstrumentGenerator(SF2Generator.Pan, new SF2GeneratorAmount { Amount = (short)pan });
 
+                    // the multiplier here was brute-forced, likely not 100% accurate
                     sf2.AddInstrumentGenerator(SF2Generator.FineTune, new SF2GeneratorAmount { Amount = (short)(splitChunk.UnkPitch * 6.5)});
-                    
+
                     if (prog.CountOrFlag == 0xFF)
                         sf2.AddInstrumentGenerator(SF2Generator.KeyRange, new SF2GeneratorAmount { LowByte = (byte)(prog.StartNoteRange + k), HighByte = (byte)(prog.StartNoteRange + k) });
                     else

--- a/GT4SoundTool/Program.cs
+++ b/GT4SoundTool/Program.cs
@@ -198,7 +198,7 @@ public class Program
                     int pan = (int)Normalize(splitChunk.Pan, 0, 128, -500, 500);
                     sf2.AddInstrumentGenerator(SF2Generator.Pan, new SF2GeneratorAmount { Amount = (short)pan });
 
-                    sf2.AddInstrumentGenerator(SF2Generator.FineTune, new SF2GeneratorAmount { Amount = (short)(splitChunk.FineTunePitch * 6.5)});
+                    sf2.AddInstrumentGenerator(SF2Generator.FineTune, new SF2GeneratorAmount { Amount = (short)(splitChunk.UnkPitch * 6.5)});
                     
                     if (prog.CountOrFlag == 0xFF)
                         sf2.AddInstrumentGenerator(SF2Generator.KeyRange, new SF2GeneratorAmount { LowByte = (byte)(prog.StartNoteRange + k), HighByte = (byte)(prog.StartNoteRange + k) });

--- a/GT4SoundTool/Program.cs
+++ b/GT4SoundTool/Program.cs
@@ -198,8 +198,8 @@ public class Program
                     int pan = (int)Normalize(splitChunk.Pan, 0, 128, -500, 500);
                     sf2.AddInstrumentGenerator(SF2Generator.Pan, new SF2GeneratorAmount { Amount = (short)pan });
 
-                    //sf2.AddInstrumentGenerator(SF2Generator.CoarseTune, new SF2GeneratorAmount { Amount = (short)(splitChunk.UnkPitch)});
-
+                    sf2.AddInstrumentGenerator(SF2Generator.FineTune, new SF2GeneratorAmount { Amount = (short)(splitChunk.FineTunePitch * 6.5)});
+                    
                     if (prog.CountOrFlag == 0xFF)
                         sf2.AddInstrumentGenerator(SF2Generator.KeyRange, new SF2GeneratorAmount { LowByte = (byte)(prog.StartNoteRange + k), HighByte = (byte)(prog.StartNoteRange + k) });
                     else


### PR DESCRIPTION
Fourth byte in JamSplitChunk seems to be the right one, but it needs to be multiplied by 6.5 (I brute-forced this multiplier, I don't know why that's correct here) and as for SF2 generators, it seems FineTune instead of CoarseTune is needed here.

The out-of-tune notes seem to now be correct (or at least way closer than without any pitch correction).